### PR TITLE
feat: support ESM

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -1,15 +1,19 @@
+const assert = require('assert')
 const fs = require('fs')
 const CovBranch = require('./branch')
 const CovLine = require('./line')
 const CovFunction = require('./function')
 
 // Node.js injects a header when executing a script.
-const header = require('module').wrapper[0]
+const cjsHeader = require('module').wrapper[0]
 
 module.exports = class CovScript {
   constructor (scriptPath) {
-    const source = fs.readFileSync(scriptPath, 'utf8')
-    this.path = scriptPath
+    assert(typeof scriptPath === 'string', 'scriptPath must be a string')
+    const {path, isESM} = parsePath(scriptPath)
+    const source = fs.readFileSync(path, 'utf8')
+    this.path = path
+    this.header = isESM ? '' : cjsHeader
     this.lines = []
     this.branches = []
     this.functions = []
@@ -27,8 +31,8 @@ module.exports = class CovScript {
   applyCoverage (blocks) {
     blocks.forEach(block => {
       block.ranges.forEach(range => {
-        const startCol = Math.max(0, range.startOffset - header.length)
-        const endCol = Math.min(this.eof, range.endOffset - header.length)
+        const startCol = Math.max(0, range.startOffset - this.header.length)
+        const endCol = Math.min(this.eof, range.endOffset - this.header.length)
         const lines = this.lines.filter(line => {
           return startCol <= line.endCol && endCol >= line.startCol
         })
@@ -110,5 +114,12 @@ module.exports = class CovScript {
       functions.f[`${index}`] = fn.count
     })
     return functions
+  }
+}
+
+function parsePath (scriptPath) {
+  return {
+    path: scriptPath.replace('file://', ''),
+    isESM: scriptPath.indexOf('file://') !== -1
   }
 }

--- a/test/script.js
+++ b/test/script.js
@@ -15,6 +15,15 @@ describe('Script', () => {
         require.resolve('./fixtures/scripts/functions.js')
       )
       script.lines.length.should.equal(49)
+      script.header.length.should.equal(62) // common-js header.
+    })
+
+    it('handles ESM style paths', () => {
+      const script = new Script(
+        `file://${require.resolve('./fixtures/scripts/functions.js')}`
+      )
+      script.lines.length.should.equal(49)
+      script.header.length.should.equal(0) // ESM header.
     })
   })
 


### PR DESCRIPTION
ESM has no header like common-js, and files start with a `file://` prefix.